### PR TITLE
Match should skip unexported fields as they won't be serialized

### DIFF
--- a/dsl/matcher.go
+++ b/dsl/matcher.go
@@ -301,6 +301,9 @@ func match(srcType reflect.Type, params params) Matcher {
 
 		for i := 0; i < srcType.NumField(); i++ {
 			field := srcType.Field(i)
+			if !field.IsExported() {
+				continue
+			}
 			fieldName := getJsonFieldName(field)
 			if fieldName == "" {
 				continue

--- a/dsl/matcher_test.go
+++ b/dsl/matcher_test.go
@@ -584,6 +584,9 @@ func TestMatch(t *testing.T) {
 		Word     string `json:"word"`
 		WordDash string `json:"-,"`
 	}
+	type unexportedDTO struct {
+		unexported string
+	}
 	str := "str"
 	type args struct {
 		src interface{}
@@ -698,6 +701,13 @@ func TestMatch(t *testing.T) {
 				"word": Like("string"),
 				"-":    Like("string"),
 			},
+		},
+		{
+			name: "recursive case - struct with unexported field",
+			args: args{
+				src: unexportedDTO{},
+			},
+			want: StructMatcher{},
 		},
 		{
 			name: "base case - string",


### PR DESCRIPTION
See details in upstream PR: https://github.com/pact-foundation/pact-go/pull/201

Needed in our fork so that CI can fetch this in a `go.mod` `replace` directive until upstream is merged in and released.