### PR TITLE
Support unexported check on go < 1.17

### DIFF
--- a/dsl/matcher.go
+++ b/dsl/matcher.go
@@ -301,7 +301,8 @@ func match(srcType reflect.Type, params params) Matcher {
 
 		for i := 0; i < srcType.NumField(); i++ {
 			field := srcType.Field(i)
-			if !field.IsExported() {
+			// Skip unexported fields.
+			if field.PkgPath != "" {
 				continue
 			}
 			fieldName := getJsonFieldName(field)


### PR DESCRIPTION
Realized that [IsExported](https://pkg.go.dev/reflect#StructField.IsExported) was added in go 1.17, but most of our services aren't using that yet. Use a less readable but still functional alternative.